### PR TITLE
body.fault can be undefined, when trying to pass body.fault.faultstring

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zendrive",
   "description": "Node.js wrapper for Zendrive API",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "zendrive",
   "scripts": {
     "prestart": "npm prune && npm rebuild",

--- a/zendrive.js
+++ b/zendrive.js
@@ -24,8 +24,10 @@ function v1(opts) {
       qs: preparedParams,
       json: true
     }, function(err, res, body) {
-      if (body && body.fault || typeof body !== 'object') {
-        return callback(new Error(body.fault.faultstring || 'An error occurred'));
+      if (body && body.fault && body.fault.faultstring) {
+        return callback(new Error(body.fault.faultstring));
+      } else if (typeof body !== 'object') {
+        return callback(new Error('An error occurred'));
       }
 
       callback(err, body);


### PR DESCRIPTION
existing logic was

``` js
if (body && body.fault || typeof body !== 'object') {
  return callback(new Error(body.fault.faultstring || 'An error occurred'));
}
```

if `typeof body !== 'object'` then `body.fault` is undefined, so `body.fault.faultstring` throws an exception.
